### PR TITLE
fix: install dependencies

### DIFF
--- a/p.sh
+++ b/p.sh
@@ -184,14 +184,14 @@ else
         # wget https://github.com/spiritLHLS/peer2profit-one-click-command-installation/raw/main/p2pclient_0.60_amd64.deb
         wget https://updates.peer2profit.app/peer2profit_0.48_amd64.deb
         # dpkg -i p2pclient_0.60_amd64.deb
-        dpkg -i peer2profit_0.48_amd64.deb
+        apt install -f ./peer2profit_0.48_amd64.deb
         nohup p2pclient -l "$P2PEMAIL" >/dev/null 2>&1 &
         # rm -rf p2pclient_0.60_amd64.deb*
         rm -rf peer2profit_0.48_amd64.deb*
     else
         rm -rf *p2p*
         wget https://github.com/spiritLHLS/peer2profit-one-click-command-installation/raw/main/p2pclient_0.60_i386.deb
-        dpkg -i p2pclient_0.60_i386.deb
+        apt install -f ./p2pclient_0.60_i386.deb
         nohup p2pclient -l "$P2PEMAIL" >/dev/null 2>&1 &
         rm -rf p2pclient_0.60_i386.deb*
     fi


### PR DESCRIPTION
若机器之前未安装所有依赖，直接执行dpkg -i会导致依赖缺失的情况。
故修改为使用apt install -f命令来自动安装依赖。
附dpkg -i命令输出如下
```
Selecting previously unselected package peer2profit.
(Reading database ... 133107 files and directories currently installed.)
Preparing to unpack peer2profit_0.48_amd64.deb ...
Unpacking peer2profit (0.48) ...
dpkg: dependency problems prevent configuration of peer2profit:
 peer2profit depends on libxcb-glx0; however:
  Package libxcb-glx0 is not installed.
 peer2profit depends on libx11-xcb1; however:
  Package libx11-xcb1 is not installed.
 peer2profit depends on libxcb-icccm4; however:
  Package libxcb-icccm4 is not installed.
 peer2profit depends on libxcb-image0; however:
  Package libxcb-image0 is not installed.
 peer2profit depends on libxcb-shm0; however:
  Package libxcb-shm0 is not installed.
 peer2profit depends on libxcb-keysyms1; however:
  Package libxcb-keysyms1 is not installed.
 peer2profit depends on libxcb-randr0; however:
  Package libxcb-randr0 is not installed.
 peer2profit depends on libxcb-render-util0; however:
  Package libxcb-render-util0 is not installed.
 peer2profit depends on libxcb-sync1; however:
  Package libxcb-sync1 is not installed.
 peer2profit depends on libxcb-xfixes0; however:
  Package libxcb-xfixes0 is not installed.
 peer2profit depends on libxcb-render0; however:
  Package libxcb-render0 is not installed.
 peer2profit depends on libxcb-shape0; however:
  Package libxcb-shape0 is not installed.
 peer2profit depends on libxcb-xinerama0; however:
  Package libxcb-xinerama0 is not installed.
 peer2profit depends on libxcb-xkb1; however:
  Package libxcb-xkb1 is not installed.
 peer2profit depends on libxkbcommon-x11-0; however:
  Package libxkbcommon-x11-0 is not installed.
 peer2profit depends on libxkbcommon0; however:
  Package libxkbcommon0 is not installed.
 peer2profit depends on libgl1; however:
  Package libgl1 is not installed.
 peer2profit depends on libxcb-util1; however:
  Package libxcb-util1 is not installed.

dpkg: error processing package peer2profit (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 peer2profit
```